### PR TITLE
Added additional mapping to Ukrainian language for correct benchmark and translate pipelines running

### DIFF
--- a/translators/mbart.py
+++ b/translators/mbart.py
@@ -53,6 +53,7 @@ class mBARTTranslator(BaseTranslator):
         'th': 'th_TH',
         'tl': 'tl_XX',
         'uk_UA': 'uk_UA',
+        'uk': 'uk_UA',
         'ur': 'ur_PK',
         'xh': 'xh_ZA',
         'gl': 'gl_ES',

--- a/translators/nllb.py
+++ b/translators/nllb.py
@@ -20,6 +20,7 @@ class NLLBTranslator(BaseTranslator):
         'eu': 'eus_Latn',
         'it': 'ita_Latn',
         'uk-UA': 'ukr_Cyrl',
+        'uk': 'ukr_Cyrl',
         'id': 'ind_Latn',
         'ar': 'arb_Arab',
         'fi': 'fin_Latn',


### PR DESCRIPTION
Currently is impossible to run benchmarks for nllb and mbart in terms of missed mapping for 'uk' language.

Running with uk code fails in translate.py in terms of missing key.
In opposite, running with uk_UA code fails during opus mapping extraction with error below:

<details>
  <summary>Log of error</summary>
`[---- LLaMa2Lang ----] Starting benchmarking from en to uk_UA for models ['opus', 'm2m_1.2b', 'madlad_3b', 'mbart', 'nllb_1.3b'] on 100 records on device cuda:0
Traceback (most recent call last):
  File "/content/LLaMa2lang/benchmark.py", line 105, in <module>
    main()
  File "/content/LLaMa2lang/benchmark.py", line 59, in main
    dataset = load_dataset("opus100", f'{source_language}-{target_language}', split=f'train[{start}:{start+n}]').shuffle().select(range(n))
  File "/usr/local/lib/python3.10/dist-packages/datasets/load.py", line 2128, in load_dataset
    builder_instance = load_dataset_builder(
  File "/usr/local/lib/python3.10/dist-packages/datasets/load.py", line 1851, in load_dataset_builder
    builder_instance: DatasetBuilder = builder_cls(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 373, in __init__
    self.config, self.config_id = self._create_builder_config(
  File "/usr/local/lib/python3.10/dist-packages/datasets/builder.py", line 540, in _create_builder_config
    raise ValueError(
ValueError: BuilderConfig 'en-uk_UA' not found. Available: ['af-en', 'am-en', 'an-en', 'ar-en', 'as-en', 'az-en', 'be-en', 'bg-en', 'bn-en', 'br-en', 'bs-en', 'ca-en', 'cs-en', 'cy-en', 'da-en', 'de-en', 'dz-en', 'el-en', 'en-eo', 'en-es', 'en-et', 'en-eu', 'en-fa', 'en-fi', 'en-fr', 'en-fy', 'en-ga', 'en-gd', 'en-gl', 'en-gu', 'en-ha', 'en-he', 'en-hi', 'en-hr', 'en-hu', 'en-hy', 'en-id', 'en-ig', 'en-is', 'en-it', 'en-ja', 'en-ka', 'en-kk', 'en-km', 'en-ko', 'en-kn', 'en-ku', 'en-ky', 'en-li', 'en-lt', 'en-lv', 'en-mg', 'en-mk', 'en-ml', 'en-mn', 'en-mr', 'en-ms', 'en-mt', 'en-my', 'en-nb', 'en-ne', 'en-nl', 'en-nn', 'en-no', 'en-oc', 'en-or', 'en-pa', 'en-pl', 'en-ps', 'en-pt', 'en-ro', 'en-ru', 'en-rw', 'en-se', 'en-sh', 'en-si', 'en-sk', 'en-sl', 'en-sq', 'en-sr', 'en-sv', 'en-ta', 'en-te', 'en-tg', 'en-th', 'en-tk', 'en-tr', 'en-tt', 'en-ug', 'en-uk', 'en-ur', 'en-uz', 'en-vi', 'en-wa', 'en-xh', 'en-yi', 'en-yo', 'en-zh', 'en-zu', 'ar-de', 'ar-fr', 'ar-nl', 'ar-ru', 'ar-zh', 'de-fr', 'de-nl', 'de-ru', 'de-zh', 'fr-nl', 'fr-ru', 'fr-zh', 'nl-ru', 'nl-zh', 'ru-zh']
`

</details>